### PR TITLE
Update the shape of y_train and y_test (#12669)

### DIFF
--- a/docs/templates/datasets.md
+++ b/docs/templates/datasets.md
@@ -15,7 +15,7 @@ from keras.datasets import cifar10
 - __Returns:__
     - 2 tuples:
         - __x_train, x_test__: uint8 array of RGB image data with shape (num_samples, 3, 32, 32) or (num_samples, 32, 32, 3) based on the `image_data_format` backend setting of either `channels_first` or `channels_last` respectively.
-        - __y_train, y_test__: uint8 array of category labels (integers in range 0-9) with shape (num_samples,).
+        - __y_train, y_test__: uint8 array of category labels (integers in range 0-9) with shape (num_samples, 1).
 
 
 ---
@@ -35,7 +35,7 @@ from keras.datasets import cifar100
 - __Returns:__
     - 2 tuples:
         - __x_train, x_test__: uint8 array of RGB image data with shape (num_samples, 3, 32, 32) or (num_samples, 32, 32, 3) based on the `image_data_format` backend setting of either `channels_first` or `channels_last` respectively.
-        - __y_train, y_test__: uint8 array of category labels with shape (num_samples,).
+        - __y_train, y_test__: uint8 array of category labels with shape (num_samples, 1).
 
 - __Arguments:__
 


### PR DESCRIPTION
Update the shape of y_train and y_test in the output of CIFAR10 and CIFAR100 datasets.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md
-->

### Summary

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
